### PR TITLE
Minor fixes

### DIFF
--- a/GUI/src/cz/fidentis/gui/NavigatorTopComponent.java
+++ b/GUI/src/cz/fidentis/gui/NavigatorTopComponent.java
@@ -308,7 +308,6 @@ public final class NavigatorTopComponent extends TopComponent {
             tree.getRoot().addChild(Controller.getProjects().get(i).getTree().getRoot());
         }
 
-        jTree1.addTreeSelectionListener(tsl);
         DefaultMutableTreeNode root = new DefaultMutableTreeNode(tree.getRoot().getName());
         TreeModel m = new DefaultTreeModel(processNodes(root, tree.getRoot()));
         jTree1.setModel(m);

--- a/GUI/src/cz/fidentis/gui/ProjectTopComponent.java
+++ b/GUI/src/cz/fidentis/gui/ProjectTopComponent.java
@@ -337,10 +337,9 @@ public final class ProjectTopComponent extends TopComponent {
         super.componentActivated();
         if (GUIController.getSelectedProjectTopComponent() != this) {
             GUIController.setSelectedProjectTopComponent(this);
-            this.showComponents(); 
+            this.showComponents();
         }
-            GUIController.updateSelectedComponent();
-            GUIController.getNavigatorTopComponent().clearSelectionIfNeeded(this);
-     
+        GUIController.updateSelectedComponent();
+        GUIController.getNavigatorTopComponent().clearSelectionIfNeeded(this);
     }
 }

--- a/GUI/src/cz/fidentis/gui/actions/OpenProject.java
+++ b/GUI/src/cz/fidentis/gui/actions/OpenProject.java
@@ -161,6 +161,8 @@ public final class OpenProject implements ActionListener {
     }
     
     private void updateGui(ProjectTopComponent ntc, Project p) {
+        GUIController.getBlankProject(); // create panel for new project
+        
         ntc.setProject(p);
         ntc.setName(String.valueOf(GUIController.getProjects().size()));
         ntc.setDisplayName(p.getName());
@@ -212,17 +214,6 @@ public final class OpenProject implements ActionListener {
                 }
             }
             ntc.show2FacesViewer();
-            switch (comparison2f.getState()) {
-                case 1:
-                    ctc.addRegistrationComponent();
-                    break;
-                case 2:
-                    ctc.addComparisonComponent();
-                    break;
-                case 3:
-                    ctc.addPairComparisonResults();
-                    break;
-            }
         }
         if (p.getSelectedOneToManyComparison() != null) {
             OneToManyComparison comparison1N = p.getSelectedOneToManyComparison();
@@ -248,17 +239,6 @@ public final class OpenProject implements ActionListener {
                 }
             }
             ntc.show1toNViewer();
-            switch (comparison1N.getState()) {
-                case 1:
-                    ctc.addOneToManyRegistrationComponent();
-                    break;
-                case 2:
-                    ctc.addOneToManyComparisonComponent();
-                    break;
-                case 3:
-                    ctc.addOneToManyComparisonResults();
-                    break;
-            }
         }
         if (p.getSelectedBatchComparison() != null) {
             BatchComparison comparison = p.getSelectedBatchComparison();
@@ -278,21 +258,9 @@ public final class OpenProject implements ActionListener {
                 }
             }
             ntc.showBatchViewer();
-            switch (comparison.getState()) {
-                case 1:
-                    ctc.addBatchRegistrationComponent();
-                    break;
-                case 2:
-                    ctc.addBatchComparisonComponent();
-                    break;
-                case 3:
-                    ctc.addBatchComparisonResults();
-                    break;
-            }
         }
-        GUIController.getBlankProject(); // create panel for new project
-        ntc.requestActive();
         GUIController.updateNavigator();
+        ntc.requestActive();
     }
 
     private void createComposite(Element projectE, ProjectTopComponent tc) {
@@ -1121,8 +1089,9 @@ public final class OpenProject implements ActionListener {
                     } catch (IOException | ParserConfigurationException | SAXException ex) {
                         JOptionPane.showMessageDialog(null, "Failed to open project");
                         ex.printStackTrace();
+                    } finally {
+                        p.finish();
                     }
-                    p.finish();
                 }
             };
             Thread t = new Thread(r);

--- a/GUI/src/cz/fidentis/gui/actions/SaveProject.java
+++ b/GUI/src/cz/fidentis/gui/actions/SaveProject.java
@@ -754,6 +754,8 @@ public final class SaveProject implements ActionListener {
             }
             final File outFile = selected;
             final ProjectTopComponent tc = GUIController.getSelectedProjectTopComponent();
+            tc.setDisplayName(outFile.getName());
+            tc.getProject().setName(outFile.getName());
             
             Runnable r = new Runnable() {
                 @Override

--- a/GUI/src/cz/fidentis/gui/actions/SaveProject.java
+++ b/GUI/src/cz/fidentis/gui/actions/SaveProject.java
@@ -756,6 +756,7 @@ public final class SaveProject implements ActionListener {
             final ProjectTopComponent tc = GUIController.getSelectedProjectTopComponent();
             tc.setDisplayName(outFile.getName());
             tc.getProject().setName(outFile.getName());
+            GUIController.updateNavigator();
             
             Runnable r = new Runnable() {
                 @Override

--- a/GUI/src/cz/fidentis/gui/comparison_batch/BatchRegistrationConfiguration.java
+++ b/GUI/src/cz/fidentis/gui/comparison_batch/BatchRegistrationConfiguration.java
@@ -991,8 +991,6 @@ public class BatchRegistrationConfiguration extends javax.swing.JPanel {
                         jButton1.setEnabled(true);
                     }
 
-                    p.finish();
-
                 } else if (jComboBox6.getSelectedIndex() == 0) {
                     int size = tc.getProject().getSelectedBatchComparison().getModels().size();
                     p.start(size);
@@ -1066,6 +1064,7 @@ public class BatchRegistrationConfiguration extends javax.swing.JPanel {
                 if (jCheckBox10.isSelected()) {
                     GUIController.getConfigurationTopComponent().getBatchComparisonConfiguration().computeComparison(tc);
                 }
+                p.finish();
                 GUIController.updateNavigator();
             }
         };


### PR DESCRIPTION
- removed inapropriate `jTree1.addTreeSelectionListener(tsl);` (it was added on every update which lead to stacking of calls to process selection changes)
- in `OpenProject` action: moved `GUIController.getBlankProject();` as it caused to hide configuration panel, removed obsolete switches
- in `SaveProject` action: name of project is changed to the name of file we are saving to, it will help user see which project was saved and where
- fixed batch comparison registration, which did not finish progress handle if registering using FPs